### PR TITLE
scoopによるインストールの自動化

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ You can use under the MIT licence. Please see [a licence file](LICENSE) for more
 
 ## Install
 Download and unzip the ZIP file in the release page.
+
+## Install by scoop
+You can install by scoop.
+support by nodokaha(github link is [nodokaha/myscoop](https://github.com/nodokaha/myscoop))
+
+This is presented by nodokaha, not OpenPraparatHelper creator.
+
+If you get problem, please submit issue to nodokaha.
+
+*warning* This is not build script.
+```cmd
+ScoopInstall.bat
+```
+
 ## Last Release
 See [V1.0.0.0](https://github.com/furaku/OpenPraparatHelper/releases/tag/v1.0.0.0)
 
@@ -47,6 +61,14 @@ MIT ライセンスの下で使用可能です。詳しくは[ライセンスフ
 
 ## インストール
 リリースページに有るZIPファイルをダウンロードし、解凍してください。
+
+## scoopによるインストール
+scoopパッケージマネージャーによるインストールがサポート（[nodokaha/myscoop](https://github.com/nodokaha/myscoop)でこのソフトの作者様とは別にnodokahaが保守させて頂いています。）されています。
+
+batファイルを実行するとショートカット含めコマンドプロンプトでパスが通った状態でインストールされます。これはリリースからのバイナリをインストールするものであり、ソースコードをビルドしてインストールするものではありませんのでご注意ください。
+```cmd
+ScoopInstall.bat
+```
 
 ## 最新リリース
 [V1.0.0.0](https://github.com/furaku/OpenPraparatHelper/releases/tag/v1.0.0.0)を参照してください。

--- a/ScoopInstall.bat
+++ b/ScoopInstall.bat
@@ -1,3 +1,4 @@
+winget install Microsoft.PowerShell
 pwsh -ep RemoteSigned -Command "irm get.scoop.sh | iex"
 pwsh -Command "scoop bucket add nodoka https://github.com/nodokaha/myscoop"
 pwsh -Command "scoop install OpenPraparatHelper"

--- a/ScoopInstall.bat
+++ b/ScoopInstall.bat
@@ -1,0 +1,3 @@
+pwsh -ep RemoteSigned -Command "irm get.scoop.sh | iex"
+pwsh -Command "scoop bucket add nodoka https://github.com/nodokaha/myscoop"
+pwsh -Command "scoop install OpenPraparatHelper"


### PR DESCRIPTION
scoopパッケージマネージャー[scoop.sh](https://scoop.sh)によって、github上でリリースされているバイナリをwindowsに手軽にインストールする方法をまとめさせて頂きました！（対応状況はwindows10以上）
英語が不安すぎるのでREADMEは念入りにご確認をお願いします…